### PR TITLE
Revise script to use command line arguments instead of prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
 ## AWS-S3-URL-Listing
-A script that lists the URL addresses of all objects in a specific folder within a specific bucket.
+
+A script that lists the URLs of all objects in a specific folder of a specific S3 bucket.
+
 ## Preparing
 ```python
 pip install awscli
 pip install boto3
 ```
+
 #### AWS Configuration
- * [Configuring the AWS CLI](https://docs.aws.amazon.com/en_us/cli/latest/userguide/cli-chap-configure.html)
+
+See [Configuring the AWS CLI](https://docs.aws.amazon.com/en_us/cli/latest/userguide/cli-chap-configure.html).
+
+Simplified steps:
+ 1. Make the IAM user part of a group that has the Administrator Access, Amazon S3 Full Access, and PowerUserAccess policies attached.
+ 2. Retrieve the AWS Access Key ID and the AWS Secrets Access Key for the IAM user.
+ 3. On the command line, run `aws configrure` enter the AWS Access Key ID and the AWS Secrets Access Key when prompted, along with your default region, if desired.
+
+## Usage
+
+```
+python app.py --region YOUR-REGION --bucket YOUR-BUCKET --folder YOUR-FOLDER
+```
+
+If you're frequently working with a specific region and bucket, modify `app.py` with those defaults so you don't need to include them on the command line.
+
+The `folder` value defaults to '', which then lists all objects within the bucket. A folder name can include sub-folders separated by /. If you have spaces in any folder name, put quotes around the entire folder value, such as:
+
+```
+python app.py --region YOUR-REGION --bucket YOUR-BUCKET --folder "images/marketing 2024"
+```
 
 ## Note
-This script was written for Virtual-hosted style URL. You can customize it according to the URL style you use. (Path style URL
-etc.)
+This script was written for Virtual-hosted style URL. You can customize it according to the URL style you use by changing the `url_root` string on line 34.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import boto3
 import urllib.parse
-
+import argparse
 
 def get_matching_s3_objects(bucket, prefix="", suffix=""):
 
@@ -29,15 +29,26 @@ def get_matching_s3_objects(bucket, prefix="", suffix=""):
                     yield obj
 
 
-def get_matching_s3_keys(bucket, prefix="", suffix=""):
+def get_matching_s3_keys(bucket, region, prefix="", suffix=""):
+
+    url_root = f'https://{bucket}.{region}.amazonaws.com/'
 
     for obj in get_matching_s3_objects(bucket, prefix, suffix):
         key = obj["Key"]
         key_ae = urllib.parse.quote_plus(key, safe="/")
-        print(f'https://{bucket_n}.{region}.amazonaws.com/{key_ae}')
+        print(url_root + key_ae)
+        
 
-region = input("Region :   ")
-bucket_n = input("Bucket name :  ")
-folder = input("Folder name   :  ")
-get_matching_s3_keys(bucket_n, folder)
+def main():
+    # Modify the defaults if you use the same region and bucket frequently
+    parser = argparse.ArgumentParser(description='Process some command line arguments.')
+    parser.add_argument('--region', type=str, required=False, default='YOUR_REGION', help='S3 region')
+    parser.add_argument('--bucket', type=str, required=False, default='YOUR-BUCKET', help='S3 bucket')
+    parser.add_argument('--folder', type=str, required=False, default='', help='Optional folder path within the bucket to enumerate')
 
+    args = parser.parse_args()
+
+    get_matching_s3_keys(args.bucket, args.region, args.folder)
+
+if __name__ == "__main__":
+    main()

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ def get_matching_s3_keys(bucket, region, prefix="", suffix=""):
 def main():
     # Modify the defaults if you use the same region and bucket frequently
     parser = argparse.ArgumentParser(description='Process some command line arguments.')
-    parser.add_argument('--region', type=str, required=False, default='YOUR_REGION', help='S3 region')
+    parser.add_argument('--region', type=str, required=False, default='YOUR-REGION', help='S3 region')
     parser.add_argument('--bucket', type=str, required=False, default='YOUR-BUCKET', help='S3 bucket')
     parser.add_argument('--folder', type=str, required=False, default='', help='Optional folder path within the bucket to enumerate')
 


### PR DESCRIPTION
Hi Çağdaş, thanks so much for making this script available. It's just what I needed for some work I'm doing with S3. Because I needed to run the script repeatedly, I modified the script to accept command-line arguments instead of input prompts. I also refactored the code to not depend on global variables like bucket_n.

I also updated the readme with a bit of usage that I wanted to see originally as well as a bit more for AWS CLI configuration. I'm not sure that all the policies I name are necessary, but that's what's working for me. I added these because I had to do a bit of digging and figured that someone else might like that info up front.